### PR TITLE
Add git ignore for node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
IMO build artifacts that aren't meant to be committed should be ignored.  Unless there is a good reason not to I think this should be merged.