### PR TITLE
Add in batch script to make running sugarizer easier

### DIFF
--- a/start-sugarizer.bat
+++ b/start-sugarizer.bat
@@ -1,0 +1,4 @@
+@echo off
+
+start "" "C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --allow-file-access-from-files %~dp0index.html
+EXIT


### PR DESCRIPTION
Addresses issue #16. Simply double-clicking `start-sugarizer.bat` *should* open Sugarizer in Chrome with the `--allow-file-access-from-files` flag set, as long as the batch file is in the same directory as `index.html`.